### PR TITLE
fix(carry-on): Fixes storage vessels (sortable) patch

### DIFF
--- a/assets/sortablestorage/patches/carryon.json
+++ b/assets/sortablestorage/patches/carryon.json
@@ -64,7 +64,7 @@
     "file": "sortablestorage:blocktypes/clay/storagevesselsortable.json",
     "side": "server",
     "op": "add",
-    "path": "/behaviorsByType/*/-",
+    "path": "/behaviors/-",
     "value": {
       "name": "Carryable",
       "properties": {


### PR DESCRIPTION
This commit https://github.com/SpearAndFang/sortablestorage/commit/7ed681cf938ef95c4ccf378dc25d25dc8b9c2ea8 replaced `behaviorsByType` with simply `behaviors` in `assets/sortablestorage/blocktypes/clay/storagevesselsortable.json`.

However the Carry On patch was not updated to reflect that, thus breaking "carryability" of sortable storage vessels. This PR fixes that.